### PR TITLE
padManager.getPad needs "text" parameter

### DIFF
--- a/exportMediaWiki.js
+++ b/exportMediaWiki.js
@@ -292,7 +292,7 @@ function _analyzeLine(text, aline, apool)
 
 exports.getPadMediaWikiDocument = function (padId, revNum, callback)
 {
-  padManager.getPad(padId, function (err, pad)
+  padManager.getPad(padId, null, function (err, pad)
   {
     if(ERR(err, callback)) return;
 


### PR DESCRIPTION
I tried running this extension on 1.7.5 and requests to get the mediawiki formatted export timed out.
I saw an error in the logs about an invalid text parameter passed to the getPad function, and it turns out that the behavior of that function was changed a while ago.

This fixes that issue, but unfortunately, requests still time out :-/